### PR TITLE
PP-246 Accessibiity changes

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,9 @@
 .wrapper {
   padding: 16px;
 }
+
+@mixin focus-outline {
+  border: solid 2px #1a1a1a;
+  transition: border-color 85ms ease-out;
+  box-shadow: 0 0 0 3px #0072c6;
+}

--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -7,7 +7,8 @@
       "oldest-first": "Oldest first",
       "submit": "Search",
       "invalid-date": "Invalid date",
-      "results-count": "results"
+      "results-count": "results",
+      "clear-all": "Clear all"
     },
     "DECISIONS": {
       "form-title": "Search decisions",
@@ -24,7 +25,8 @@
       "past-month": "Past month",
       "past-year": "Past year",
       "topic": "Topic",
-      "choose-topic": "Choose topic"
+      "choose-topic": "Choose topic",
+      "date-select": "Date range"
     }
   },
   "fi": {
@@ -35,7 +37,8 @@
       "oldest-first": "Vanhin ensin",
       "submit": "Hae",
       "invalid-date": "Päivämäärä ei ole oikeassa muodossa",
-      "results-count": "hakutulosta"
+      "results-count": "hakutulosta",
+      "clear-all": "Tyhjennä valinnat"
     },
     "DECISIONS": {
       "form-title": "Hae päätöksiä",
@@ -52,7 +55,8 @@
       "past-month": "Viime kuukausi",
       "past-year": "Viime vuosi",
       "topic": "Aihe",
-      "choose-topic": "Valitse aihe"
+      "choose-topic": "Valitse aihe",
+      "date-select": "Ajankohta"
     }
   }
 }

--- a/src/modules/decisions/components/form/FormContainer.scss
+++ b/src/modules/decisions/components/form/FormContainer.scss
@@ -19,16 +19,35 @@ $input-font-size: 18px;
   label {
     font-size: 16px;
     font-weight: 500;
+    display: block;
+    margin-bottom: var(--spacing-3-xs);
+
+    @media (max-width: 768px) {
+      display: none;
+    }
+  }
+
+  //Exception
+  .SearchBar label {
+    display: block;
+  }
+
+  .DateSelect__collapsible-element label {
+    display: block;
   }
 
   .form-element {
     margin-bottom: 16px;
 
-    > input, > button, &.search-bar input {
+    > input, > button, &.SearchBar__input input {
       border: 2px solid #808080;
       border-radius: 2px;
       height: $input-height;
       font-size: $input-font-size;
+
+      &:focus, &:focus-within, &:hover {
+        border-color: #1a1a1a;
+      }
     }
   }
 

--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -14,6 +14,11 @@ import './FormContainer.scss';
 type FormContainerState = {
   phrase: string,
   categories: Array<string>,
+  queryCategories: Array<string>,
+  from: any,
+  queryFrom: any,
+  to: any,
+  queryTo: any
   errors: FormErrors
 };
 
@@ -21,14 +26,27 @@ class FormContainer extends React.Component {
   state: FormContainerState = {
     phrase: '',
     categories: [],
-    errors: {}
+    queryCategories: [],
+    errors: {},
+    from: undefined,
+    to: undefined,
+    queryFrom: undefined,
+    queryTo: undefined,
   };
 
   searchBar = React.createRef<any>();
 
   handleSubmit = (event: any) => {
+    console.log('handleSubmit')
     event.preventDefault();
     this.searchBar.current.triggerQuery();
+    this.setState({
+      queryCategories: this.state.categories
+    });
+    this.setState({
+      queryFrom: this.state.from,
+      queryTo: this.state.to
+    })
   };
 
   changePhrase = (value: any) => {
@@ -43,10 +61,22 @@ class FormContainer extends React.Component {
     });
   }
 
+  setFrom = (from: any) => {
+    this.setState({
+      from: from
+    });
+  }
+
+  setTo = (to: any) => {
+    this.setState({
+      to: to
+    });
+  }
+
   setErrors = (errors: FormErrors) => this.setState({errors});
 
   render() {
-    const { errors, phrase, categories } = this.state;
+    const { errors, phrase, categories, queryCategories, from, to, queryFrom, queryTo } = this.state;
 
     return(
       <div className='FormContainer wrapper form-wrapper'>
@@ -65,6 +95,29 @@ class FormContainer extends React.Component {
           </div>
           <div className='FormContainer__lower-fields'>
             <ReactiveComponent
+              componentId='meeting_date'
+              defaultQuery={() => ({
+                query: {
+                  range: {
+                    meeting_date: {}
+                  }
+                }
+              })}
+              render={({ setQuery }) => (
+                <DateSelect
+                  setQuery={setQuery}
+                  errors={errors}
+                  setErrors={this.setErrors}
+                  to={to}
+                  from={from}
+                  setFrom={this.setFrom}
+                  setTo={this.setTo}
+                  queryFrom={queryFrom}
+                  queryTo={queryTo}
+                />
+              )}
+            />
+            <ReactiveComponent
               componentId='top_category_name'
               defaultQuery={() => ({
                 aggs: {
@@ -81,23 +134,7 @@ class FormContainer extends React.Component {
                   setQuery={setQuery}
                   setValue={this.setCategories}
                   value={categories}
-                />
-              )}
-            />
-            <ReactiveComponent
-              componentId='meeting_date'
-              defaultQuery={() => ({
-                query: {
-                  range: {
-                    meeting_date: {}
-                  }
-                }
-              })}
-              render={({ setQuery }) => (
-                <DateSelect
-                  setQuery={setQuery}
-                  errors={errors}
-                  setErrors={this.setErrors}           
+                  queryValue={queryCategories}
                 />
               )}
             />

--- a/src/modules/decisions/components/form/SearchBar.scss
+++ b/src/modules/decisions/components/form/SearchBar.scss
@@ -1,5 +1,11 @@
+@import '../../../../index.scss';
+
 .SearchBar {
   @media (min-width: 1248px) {
     width: 894px;
+  }
+
+  .SearchBar__input:focus-within input {
+    @include focus-outline;
   }
 }

--- a/src/modules/decisions/components/form/SearchBar.tsx
+++ b/src/modules/decisions/components/form/SearchBar.tsx
@@ -25,15 +25,12 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
         ]}
         aggregationField={'issue_id'}
         placeholder={t('DECISIONS:search-bar-placeholder')}
-        className='search-bar search-bar__decisions form-element'
+        className='SearchBar__input form-element'
         autosuggest={false}
         iconPosition={'right'}
         icon={<IconSearch />}
         value={value}
         onChange={setValue}
-        react={{
-          and: 'meeting_date'
-        }}
       />
     </div>
   );

--- a/src/modules/decisions/components/form/filters/CategorySelect.scss
+++ b/src/modules/decisions/components/form/filters/CategorySelect.scss
@@ -1,9 +1,18 @@
 .CategorySelect {
+
+  > div {
+    border-radius: 2px;
+  }
+
   div[role="link"] {
     background: #000;
     color: #fff;
     border-radius: 24px;
     font-size: 14px;
-    padding: 0 10px;
+    padding: 2px 10px;
+  }
+
+  li[role="option"] {
+    --multiselect-checkbox-background-selected: #000;
   }
 }

--- a/src/modules/decisions/components/form/filters/CategorySelect.tsx
+++ b/src/modules/decisions/components/form/filters/CategorySelect.tsx
@@ -8,10 +8,11 @@ type Props = {
   aggregations: any,
   setQuery: Function,
   setValue: Function,
-  value: Array<string>
+  value: Array<string>,
+  queryValue: Array<string>
 }
 
-const CategorySelect = ({aggregations, setQuery, setValue, value}: Props) => {
+const CategorySelect = ({ aggregations, setQuery, setValue, value, queryValue }: Props) => {
   let categories: Array<any> = [];
   const { t } = useTranslation();
 
@@ -27,14 +28,14 @@ const CategorySelect = ({aggregations, setQuery, setValue, value}: Props) => {
   }
 
   const triggerQuery = useCallback(() => {
-    if(value.length) {
+    if(queryValue.length) {
       setQuery({
         query: {
           terms: { 
-            top_category_name: value
+            top_category_name: queryValue
           }
         },
-        value: value
+        value: queryValue
       });
     }
     else {
@@ -43,11 +44,11 @@ const CategorySelect = ({aggregations, setQuery, setValue, value}: Props) => {
         values: []
       });
     }
-  }, [value, setQuery]);
+  }, [queryValue, setQuery]);
 
   useEffect(() => {
     triggerQuery();
-  }, [value, setQuery, triggerQuery])
+  }, [queryValue, setQuery, triggerQuery])
 
   const onChange = (categories: Array<any>) => {
     const values = categories.map(category => category.value);

--- a/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
+++ b/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
@@ -46,7 +46,7 @@ const SelectedFiltersContainer = ({ categories, setCategories }: Props) => {
                 className='SelectedFilters__filter SelectedFilters__clear-filters'
                 onClick={() => setCategories([])}
               >
-                {t('SEARCH:Clear all')}
+                {t('SEARCH:clear-all')}
               </button>
             </div>
           )

--- a/src/modules/decisions/components/form/filters/date/DateInput.scss
+++ b/src/modules/decisions/components/form/filters/date/DateInput.scss
@@ -1,4 +1,6 @@
 .DateInput {
+  margin-bottom: var(--spacing-xs);
+
   &.DateInput-wrapper {
     position: relative;
   }

--- a/src/modules/decisions/components/form/filters/date/DateSelect.scss
+++ b/src/modules/decisions/components/form/filters/date/DateSelect.scss
@@ -1,4 +1,6 @@
+@import '../../../../../../index.scss';
 $collapsible_height: 56px;
+
 
 .DateSelect {
   &.dateselect-wrapper {
@@ -36,8 +38,20 @@ $collapsible_height: 56px;
 
     color: #808080;
 
+    svg {
+      color: #000000;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+
     &:focus:hover {
       color: #000000;
+    }
+
+    &:focus-visible {
+      outline: none;
     }
   }
 
@@ -46,7 +60,7 @@ $collapsible_height: 56px;
     border-top: none;
     top: $collapsible_height;
     background-color: #fff; 
-    z-index: 1;
+    z-index: 2;
     width: 100%;
   }
 
@@ -58,20 +72,45 @@ $collapsible_height: 56px;
   .DateSelect__datepicker-container {
     padding: 16px;
     padding-top: 31px;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
+
+    @media (min-width: 768px) {
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
+    }
+
+    @media (min-width: 1200px) {
+      display: block;
+    }
   }
   
   .DateSelect__date-fields-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
     margin-bottom: 31px;
 
     svg {
       margin-left: 15px;
       margin-right: 15px;
+    }
+
+    @media (min-width: 768px) {
+      margin-right: 16px;
+      margin-bottom: 0;
+    }
+
+    @media (min-width: 1200px) {
+      margin-bottom: 31px;
+    }
+  }
+
+  .DateSelect__date-fields-divider {
+    display: none;
+
+    @media (min-width: 768px) {
+      display: inline-block;
+    }
+
+    @media (min-width: 1200px) {
+      display: none;
     }
   }
 
@@ -83,29 +122,44 @@ $collapsible_height: 56px;
     width: 100%;
     height: $collapsible_height;
 
-    &:not(:diabled):hover {
+    &:not(:disabled):hover {
       border-color:#cccccc;
     }
   }
 
   .DateSelect__predefined-ranges-container {
-    padding-left: 16px;
-    padding-right: 16px;
-
     fieldset {
       --spacing-row: 0;
       --spacing-gap: 0;
+      margin: 0;
     }
 
     fieldset > div {
-      --spacing-row: 0;
-      --spacing-gap: 0;
+      display: block;
 
       & > div {
+        padding-left: 16px;
+        padding-right: 16px;
         height: $collapsible_height;
         display: flex;
         align-items: center;
         width: 100%;
+
+        & > div {
+          width: 100%;
+        }
+        
+        & > div label {
+          width: 100%;
+        }
+
+        & > div label:after {
+          --background-selected: #000000;
+          --background-hover: #000000;
+          --border-color-selected: #000000;
+          --border-color-selected-focus: #000000;
+          --border-color-selected-hover: #000000;
+        }
       }
     }
   }
@@ -113,5 +167,9 @@ $collapsible_height: 56px;
   .DateSelect__collapsible-handle {
     pointer-events: none;
   }
+
+  &:focus-within .DateSelect__collapsible-control  {
+    @include focus-outline;
+  }  
 }
 

--- a/src/modules/decisions/components/results/ResultCard.scss
+++ b/src/modules/decisions/components/results/ResultCard.scss
@@ -6,8 +6,13 @@
   margin-bottom: 24px;
   width: 100%;
   min-height: 378px;
+  overflow: hidden;
 
-  @media (min-width: '1200px') {
+  @media (min-width: 768px) {
+    width: calc(50% - 24px);
+  }
+
+  @media (min-width: 1200px) {
     max-width: 384px; 
   }
 }

--- a/src/modules/decisions/components/results/ResultsContainer.scss
+++ b/src/modules/decisions/components/results/ResultsContainer.scss
@@ -4,6 +4,17 @@
   .ResultsContainer__container {
     padding: var(--spacing-s);
 
+    @media (min-width: 768px) {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+
+      > div:first-child {
+        width: auto;  
+        display: inline-flex;
+      }
+    }
+
     @media (min-width: 1248px) {
       margin-left: auto;
       margin-right: auto;
@@ -25,8 +36,16 @@
   align-items: center;
   margin-bottom: 32px;
 
+  @media (min-width: 768px) {
+    margin-bottom: 0;
+  }
+
   .stats__count {
     font-size: 20px;
+
+    @media (min-width: 768px) {
+      margin-right: 24px;
+    }
   }
 
   .stats__count strong {

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -13,10 +13,10 @@ import './ResultsContainer.scss';
 
 const ResultsContainer = () => {
   const [sort, setSort] = useState<sortBy|undefined>('desc');
-  const [size, setSize] = useState<number>(10);
+  const [size, setSize] = useState<number>(12);
   const { t } = useTranslation();
 
-  const getPrevPages = (current: number, pages: number, totalPages: number) => {
+  const getPagination = (current: number, pages: number, totalPages: number) => {
     const pagesPerSide = (pages - 1) / 2;
     let pagesLeft = pagesPerSide * 2;
     let prevPages: Array<number> = [];
@@ -72,7 +72,7 @@ const ResultsContainer = () => {
             </div>
           )}
           renderPagination={({ pages, totalPages, currentPage, setPage, setSize }) => {
-            const { prevPages, nextPages } = getPrevPages(currentPage, pages, totalPages)
+            const { prevPages, nextPages } = getPagination(currentPage, pages, totalPages)
             const prevPageExists = currentPage - 1 >= 0;
             const nextPageExists = currentPage + 1 < totalPages;
             const selectPage = Number.isFinite(totalPages) && (

--- a/src/modules/decisions/components/results/SizeSelect.tsx
+++ b/src/modules/decisions/components/results/SizeSelect.tsx
@@ -16,21 +16,21 @@ const SortSelect = ({ setSize }: Props) => {
       }}
       label={null}
       defaultValue={{
-        label: '10',
-        value: 10
+        label: '12',
+        value: 12
       }}
       options={[
         {
-          label: '10',
-          value: 10
+          label: '12',
+          value: 12
         },
         {
-          label: '50',
-          value: 50
+          label: '48',
+          value: 48
         },
         {
-          label: '100',
-          value: 100
+          label: '96',
+          value: 96
         }
       ]}
       onChange={({value}: any) => setSize(value)}

--- a/src/modules/decisions/components/results/SortSelect.scss
+++ b/src/modules/decisions/components/results/SortSelect.scss
@@ -1,0 +1,7 @@
+.SortSelect {
+  @media (min-width: 768px) {
+    width: 328px;
+    display: inline-block;
+    margin-left: auto;
+  }
+}

--- a/src/modules/decisions/components/results/SortSelect.tsx
+++ b/src/modules/decisions/components/results/SortSelect.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Select } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
+import './SortSelect.scss';
+
 type Props = {
   setSort: Function
 };


### PR DESCRIPTION
Accessibility changes:
Queries are now executed only when submitting the form
Hover/focus -states uniformity

Visual changes:
Result cards are 50% width in table size
Size / sort selects match the sketch in desktop size
Datepicker-view reworked to create more space

To test:

Frontend:
 - Run `npm start`

Backend:
- Checkout to dev. Run `make up`.

Troubleshooting:
If you are not getting any results, run `docker ps` in your backend. If Elastic service is not running, try running `sudo sysctl -w vm.max_map_count=524288` and restarting (re-run `make up`) 

Testing the changes:

Test the form by using it. Form should be accessible. Visually it should have unifrom :hover:focus:active states.
The look should also match the sketches, with the exception of datepicker which has been slightly modified to create more space.