### PR TITLE
PP-248-query-parameters

### DIFF
--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -8,6 +8,8 @@ import SelectedFiltersContainer from './filters/SelectedFiltersContainer';
 import DateSelect from './filters/date/DateSelect';
 import CategorySelect from './filters/CategorySelect';
 import { FormErrors } from '../../types/types';
+import { updateQueryParam, getQueryParam, deleteQueryParam } from '../../../../utils/QueryString';
+import SearchComponents from '../../enum/SearchComponents';
 
 import './FormContainer.scss';
 
@@ -39,13 +41,58 @@ class FormContainer extends React.Component {
   componentDidMount() {
     const handler = (e: MediaQueryListEvent) => this.setState({ isDesktop: e.matches });
     window.matchMedia('(min-width: 1200px)').addEventListener('change', handler);
+    const from = getQueryParam('from');
+    if(from) {
+      this.setState({
+        queryFrom: from,
+        from: from
+      })
+    }
+    const to = getQueryParam('to');
+    if(to) {
+      this.setState({
+        queryTo: to,
+        to: to
+      })
+    }
+    const initialCategories = getQueryParam(SearchComponents.CATEGORY);
+    if(initialCategories) {
+      const parsedCategories = JSON.parse(initialCategories);
+      this.setState({
+        categories: parsedCategories,
+        queryCategories: parsedCategories
+      });
+    }
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
+    const { queryFrom, queryTo } = this.state;
+
+    if(queryFrom !== prevState.queryFrom) {
+      if(queryFrom) {
+        updateQueryParam('from', this.state.queryFrom);
+      }
+      else {
+        deleteQueryParam('from');
+      }
+    }
+    if(queryTo !== prevState.queryTo) {
+      if(queryTo) {
+        updateQueryParam('to', this.state.queryTo);
+      }
+      else {
+        deleteQueryParam('to');
+      }
+    }
   }
 
   searchBar = React.createRef<any>();
   koro = React.createRef<any>();
 
   handleSubmit = (event: any) => {
-    event.preventDefault();
+    if(event) {
+     event.preventDefault();
+    }
     this.searchBar.current.triggerQuery();
     this.setState({
       queryCategories: this.state.categories
@@ -53,7 +100,7 @@ class FormContainer extends React.Component {
     this.setState({
       queryFrom: this.state.from,
       queryTo: this.state.to
-    })
+    });
   };
 
   changePhrase = (value: any) => {
@@ -110,7 +157,7 @@ class FormContainer extends React.Component {
           </div>
           <div className='FormContainer__lower-fields'>
             <ReactiveComponent
-              componentId='meeting_date'
+              componentId={SearchComponents.MEETING_DATE}
               defaultQuery={() => ({
                 query: {
                   range: {
@@ -131,9 +178,10 @@ class FormContainer extends React.Component {
                   queryTo={queryTo}
                 />
               )}
+              URLParams={true}
             />
             <ReactiveComponent
-              componentId='top_category_name'
+              componentId={SearchComponents.CATEGORY}
               defaultQuery={() => ({
                 aggs: {
                   top_category_name: {
@@ -152,6 +200,7 @@ class FormContainer extends React.Component {
                   queryValue={queryCategories}
                 />
               )}
+              URLParams={true}
             />
           </div>
           <SubmitButton

--- a/src/modules/decisions/components/form/SearchBar.tsx
+++ b/src/modules/decisions/components/form/SearchBar.tsx
@@ -4,6 +4,8 @@ import { IconSearch } from 'hds-react';
 import { DataSearchProps } from '@appbaseio/reactivesearch/lib/components/search/DataSearch';
 import { useTranslation } from 'react-i18next';
 
+import IndexFields from '../../enum/IndexFields';
+import SearchComponents from '../../enum/SearchComponents';
 import './SearchBar.scss';
 
 const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value: string|undefined, setValue: any}>((props, ref) => {
@@ -15,15 +17,15 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
       <label>{t('DECISIONS:search-bar-label')}</label>
       <DataSearch
         ref={ref}
-        componentId='searchbox'
+        componentId={SearchComponents.SEARCH_BAR}
         dataField={[
-          'content_draft_proposal',
-          'content_presenter',
-          'content_resolution',
-          'issue_subject',
-          'subject'
+          IndexFields.CONTENT_DRAFT_PROPOSAL,
+          IndexFields.CONTENT_PRESENTER,
+          IndexFields.CONTENT_RESOLUTION,
+          IndexFields.ISSUE_SUBJECT,
+          IndexFields.SUBJECT
         ]}
-        aggregationField={'issue_id'}
+        aggregationField={IndexFields.ISSUE_ID}
         placeholder={t('DECISIONS:search-bar-placeholder')}
         className='SearchBar__input form-element'
         autosuggest={false}
@@ -31,6 +33,7 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
         icon={<IconSearch />}
         value={value}
         onChange={setValue}
+        URLParams={true}
       />
     </div>
   );

--- a/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
+++ b/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
@@ -23,7 +23,7 @@ const SelectedFiltersContainer = ({ categories, setCategories }: Props) => {
         className='SelectedFilters__wrapper'
         render={() => {
           const deleteCategory = (category: string) => {
-            let current = categories;
+            let current = [...categories];
             current.splice(current.indexOf(category), 1);
             setCategories(current);
           }

--- a/src/modules/decisions/components/form/filters/date/DateSelect.tsx
+++ b/src/modules/decisions/components/form/filters/date/DateSelect.tsx
@@ -8,6 +8,7 @@ import DateInput from './DateInput';
 import { FormErrors } from '../../../../types/types';
 import { isValidDate } from '../../../../../../utils/Date';
 import DatePicker from './DatePicker';
+
 import './DateSelect.scss';
 
 import classNames from 'classnames';

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -8,6 +8,8 @@ import SortSelect from './SortSelect';
 import SizeSelect from './SizeSelect';
 import { sortBy } from '@appbaseio/reactivesearch/lib/types';
 import useWindowDimensions from '../../../../hooks/useWindowDimensions';
+import SearchComponents from '../../enum/SearchComponents';
+import IndexFields from '../../enum/IndexFields';
 
 import './ResultsContainer.scss';
 
@@ -50,14 +52,18 @@ const ResultsContainer = () => {
     <div className='ResultsContainer'>
       <ReactiveList
           className='ResultsContainer__container'
-          componentId='results'
+          componentId={SearchComponents.RESULTS}
           size={size}
           pagination={true}
           pages={pages}
-          dataField={'meeting_date'}
+          dataField={IndexFields.MEETING_DATE}
           sortBy={sort}
           react={{
-              and: ['searchbox'/*, 'DateSensor', 'Category', 'sort-select'*/,'top_category_name', 'meeting_date']
+              and: [
+                SearchComponents.SEARCH_BAR,
+                SearchComponents.CATEGORY,
+                SearchComponents.MEETING_DATE
+              ]
           }}
           renderResultStats={(stats) => (
             <div className='ResultsContainer__stats'>

--- a/src/modules/decisions/enum/IndexFields.ts
+++ b/src/modules/decisions/enum/IndexFields.ts
@@ -1,0 +1,14 @@
+export const IndexFields = {
+  CONTENT_DRAFT_PROPOSAL: 'content_draft_proposal',
+  CONTENT_PRESENTER: 'content_presenter',
+  CONTENT_RESOLUTION: 'content_resolution',
+  ISSUE_ID: 'issue_id',
+  ISSUE_SUBJECT: 'issue_subject',
+  MEETING_DATE: 'meeting_date',
+  MEETING_POLICYMAKER_LINK: 'meeting_policymaker_link',
+  SUBJECT: 'subject',
+  SUBJECT_RESOLUTION: 'subject_resolution',
+  TOP_CATEGORY_NAME: 'top_category_name'
+};
+
+export default IndexFields;

--- a/src/modules/decisions/enum/SearchComponents.ts
+++ b/src/modules/decisions/enum/SearchComponents.ts
@@ -1,0 +1,8 @@
+export const SearchComponents = {
+  SEARCH_BAR: 's',
+  CATEGORY: 'category',
+  MEETING_DATE: 'meeting_date',
+  RESULTS: 'results'
+};
+
+export default SearchComponents;

--- a/src/modules/decisions/types/types.ts
+++ b/src/modules/decisions/types/types.ts
@@ -2,3 +2,11 @@ export type FormErrors = {
   from?: string,
   to?: string
 };
+
+export type Fields = {
+  top_category_name: string,
+  meeting_date: string,
+  meeting_policymaker_link: string,
+  policymaker: string,
+  subject: string
+};

--- a/src/utils/QueryString.ts
+++ b/src/utils/QueryString.ts
@@ -1,0 +1,28 @@
+export const getQueryParam = (param: string) => {
+  const params = new URLSearchParams(window.location.search);
+
+  return params.get(param);
+}
+
+export const updateQueryParam = (param: string, value: string) => {
+  let params = new URLSearchParams(window.location.search);
+  params.set(param, value);
+  const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${params.toString()}`;
+  window.history.pushState({
+    path: newUrl
+  }, '', newUrl) 
+}
+
+export const deleteQueryParam = (param: string) => {
+  let params = new URLSearchParams(window.location.search);
+  params.delete(param);
+  let newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+
+  if(params.toString().length > 0) {
+    newUrl += `?${params.toString()}`; 
+  }
+
+  window.history.pushState({
+    path: newUrl
+  }, '', newUrl) 
+}


### PR DESCRIPTION
Add search parameters to query string.

Backend actions:
- `make up` (this branch works in develop)
- Make sure you have index settings up-to-date (`make drush-cim && make drush-cr` if not)
- Make sure you have indexed data [/admin/config/search/search-api/index/decisions](https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/decisions) - if not, do it with `Queue all items for reindexing` / 'Rebuild tracking information' and 'Index now' buttons

To test (in this repo):
- Checkout branch. Make sure your .env file has `REACT_APP_ELASTIC_URL` variable which points to either `http://localhost:9200` or if you're using the elastic proxy to `:3000` OR whichever port you've configured it to run in.
- Run `npm start`. If your `3000` port is in use, you may run `PORT={PORT} npm start` to use whichever port you want.
- Once you have the app up and running, execute some search with all possible selections. Observe that these selections should be reflected in the URL. 
- Try reloading the page or opening the URL in another browser. Search results should reflect the params in the URL. 
- Try changing the query string manually. As long as the selections are valid, the search results and field values should match the changes in the URL.