### PR TITLE
PP-344: Language fixes and translations

### DIFF
--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -147,7 +147,7 @@
     "DECISIONS": {
       "city-council": "Stadsfullmäktige",
       "city-hall": "Stadsstyrelsen",
-      "decisionmaker": "Päättäjä",
+      "decisionmaker": "Beslutsfattare",
       "form-title": "Sök beslut",
       "search-bar-label": "Vad söker du?",
       "search-bar-placeholder": "Skriv sökord, t.ex. Vik",

--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -45,6 +45,23 @@
       "choose-organ": "Choose organ",
       "field": "Field of expertise",
       "choose-field": "Choose field of expertise"
+    },
+    "CATEGORIES": {
+      "00": "Hallintoasiat",
+      "01": "Henkilöstöasiat",
+      "02": "Talousasiat, verotus ja omaisuuden hallinta",
+      "03": "Lainsäädäntö ja lainsäädännön soveltaminen",
+      "04": "Kansainvälinen toiminta ja maahanmuuttopolitiikka",
+      "05": "Sosiaalitoimi",
+      "06": "Terveydenhuolto",
+      "07": "Tiedon hallinta",
+      "08": "Liikenne",
+      "09": "Turvallisuus ja yleinen järjestys",
+      "10": "Maankäyttö, rakentaminen ja asuminen",
+      "11": "Ympäristöasia",
+      "12": "Opetus- ja sivistystoimi",
+      "13": "Tutkimus- ja kehittämistoiminta",
+      "14": "Elinkeino- ja työvoimapalvelut"
     }
   },
   "fi": {
@@ -93,6 +110,23 @@
       "choose-organ": "Valitse toimielin",
       "field": "Toimiala",
       "choose-field": "Valitse toimiala"
+    },
+    "CATEGORIES": {
+      "00": "Hallintoasiat",
+      "01": "Henkilöstöasiat",
+      "02": "Talousasiat, verotus ja omaisuuden hallinta",
+      "03": "Lainsäädäntö ja lainsäädännön soveltaminen",
+      "04": "Kansainvälinen toiminta ja maahanmuuttopolitiikka",
+      "05": "Sosiaalitoimi",
+      "06": "Terveydenhuolto",
+      "07": "Tiedon hallinta",
+      "08": "Liikenne",
+      "09": "Turvallisuus ja yleinen järjestys",
+      "10": "Maankäyttö, rakentaminen ja asuminen",
+      "11": "Ympäristöasia",
+      "12": "Opetus- ja sivistystoimi",
+      "13": "Tutkimus- ja kehittämistoiminta",
+      "14": "Elinkeino- ja työvoimapalvelut"
     }
   },
   "sv": {
@@ -141,6 +175,23 @@
       "choose-organ": "Välj organ",
       "field": "Sektor",
       "choose-field": "Välj sektor"
+    },
+    "CATEGORIES": {
+      "00": "Förvaltningsärenden",
+      "01": "Personalärenden",
+      "02": "Ekonomi, beskattning och egendomsförvaltning",
+      "03": "Lagstiftning och dess tillämpning",
+      "04": "Internationell verksamhet och migrationspolitik",
+      "05": "Socialvård",
+      "06": "Hälsovård",
+      "07": "Informationshantering",
+      "08": "Trafik",
+      "09": "Säkerhet och allmän ordning",
+      "10": "Markanvändning, byggande och boende",
+      "11": "Miljöärenden",
+      "12": "Undervisnings- och bildningsväsende",
+      "13": "Forskning och utveckling",
+      "14": "Näringslivs- och arbetskraftstjänster"
     }
   }
 }

--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -1,7 +1,7 @@
 {
   "en": {
     "SEARCH": {
-      "langcode": "en",
+      "langcode": "fi",
       "prefix": "/en/",
       "per-page": "per page",
       "sort": "Sort",

--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -1,6 +1,8 @@
 {
   "en": {
     "SEARCH": {
+      "langcode": "en",
+      "prefix": "/en/",
       "per-page": "per page",
       "sort": "Sort",
       "relevancy": "Relevancy",
@@ -47,6 +49,8 @@
   },
   "fi": {
     "SEARCH": {
+      "langcode": "fi",
+      "prefix": "/fi/",
       "per-page": "kpl sivulla",
       "sort": "Lajittelu",
       "relevancy": "Osuvuus",
@@ -89,6 +93,54 @@
       "choose-organ": "Valitse toimielin",
       "field": "Toimiala",
       "choose-field": "Valitse toimiala"
+    }
+  },
+  "sv": {
+    "SEARCH": {
+      "langcode": "sv",
+      "prefix": "/sv/",
+      "per-page": "träffar per sida",
+      "sort": "Sortering",
+      "relevancy": "Relevans",
+      "most-recent-first": "Nyaste först",
+      "oldest-first": "Äldsta först",
+      "submit": "Sök",
+      "invalid-date": "Datumet är inte i rätt format",
+      "results-count": "träffar",
+      "clear-all": "Rensa alla",
+      "filters": "Avgränsa"
+    },
+    "DECISIONS": {
+      "city-council": "Stadsfullmäktige",
+      "city-hall": "Stadsstyrelsen",
+      "decisionmaker": "Päättäjä",
+      "form-title": "Sök beslut",
+      "search-bar-label": "Vad söker du?",
+      "search-bar-placeholder": "Skriv sökord, t.ex. Vik",
+      "to-less-than-from": "Slutdatumet ska vara efter startdatumet",
+      "back": "Tillbaka",
+      "choose-date": "Välj tidpunkt",
+      "choose-decisionmaker": "Välj beslutsfattare",
+      "start-date": "Från",
+      "end-date": "Till",
+      "close": "Stäng",
+      "choose-range": "Välj datum",
+      "past-week": "Senaste veckan",
+      "past-month": "Senaste månaden",
+      "past-year": "Senaste året",
+      "topic": "Ämne",
+      "trustee": "Tjänsteinnehavare",
+      "choose-topic": "Välj ämne",
+      "date-select": "Tidpunkt"
+    },
+    "POLICYMAKERS": {
+      "form-title":"Sök beslutsfattare",
+      "search-bar-placeholder": "Skriv sökord, t.ex. borgmästare",
+      "search-bar-label": "Vem söker du?",
+      "organ": "Organ",
+      "choose-organ": "Välj organ",
+      "field": "Sektor",
+      "choose-field": "Välj sektor"
     }
   }
 }

--- a/src/modules/decisions/SearchContainer.tsx
+++ b/src/modules/decisions/SearchContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ReactiveBase } from '@appbaseio/reactivesearch';
+import { useTranslation } from 'react-i18next';
 
 import Indices from '../../Indices';
 import FormContainer from './components/form/FormContainer';
@@ -19,6 +20,7 @@ type Props = {
 };
 
 const SearchContainer = ({ url }: Props) => {
+  const { t } = useTranslation();
   const [searchTriggered, setSearchState] = useState<boolean>(false);
   const triggerSearch = () => {
     setSearchState(true);
@@ -30,7 +32,10 @@ const SearchContainer = ({ url }: Props) => {
       app={Indices.PAATOKSET_DECISIONS}
       theme={baseTheme}
       >
-        <FormContainer searchTriggered={searchTriggered} triggerSearch={triggerSearch} />
+        <FormContainer
+          langcode={t('SEARCH:langcode')}
+          searchTriggered={searchTriggered}
+          triggerSearch={triggerSearch} />
         {searchTriggered &&
           <ResultsContainer />
         }

--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -278,15 +278,6 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
               <ReactiveComponent
                 componentId={SearchComponents.CATEGORY}
                 defaultQuery={() => ({
-                  query: {
-                    "bool": {
-                      "must": {
-                        "match": {
-                          "_language": this.props.langcode,
-                        }
-                      }
-                    }
-                  },
                   aggs: {
                     top_category_name: {
                       terms: {

--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -21,6 +21,7 @@ import styles from './FormContainer.module.scss';
 import classNames from 'classnames';
 
 type FormContainerProps = {
+  langcode: string,
   searchTriggered: boolean,
   triggerSearch: Function,
   t?: Function
@@ -92,7 +93,7 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
       let dm = JSON.parse(initialDm);
 
       // Decision maker values need to be transformed
-      if(t) {  
+      if(t) {
         switch(dm) {
           case t('DECISIONS:city-council'):
             dm = {label: t('DECISIONS:city-council'), value: SpecialCases.CITY_COUNCIL};
@@ -156,7 +157,7 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
   handleSubmit = (event: any) => {
     if(event) {
      event.preventDefault();
-    }    
+    }
     this.searchBar.current.triggerQuery();
     this.setState({
       queryCategories: this.state.categories,
@@ -214,7 +215,7 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
 
     let containerStyle: any = {};
     let koroStyle: any = {};
-    
+
     if(koroRef && isDesktop) {
       containerStyle.marginBottom = `${koroRef.clientHeight}px`;
       koroStyle.backgroundColor = this.props.searchTriggered ? '#f7f7f8' : 'transparent';
@@ -277,6 +278,15 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
               <ReactiveComponent
                 componentId={SearchComponents.CATEGORY}
                 defaultQuery={() => ({
+                  query: {
+                    "bool": {
+                      "must": {
+                        "match": {
+                          "_language": this.props.langcode,
+                        }
+                      }
+                    }
+                  },
                   aggs: {
                     top_category_name: {
                       terms: {
@@ -287,7 +297,7 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
                   }
                 })}
                 render={({ aggregations, setQuery }) => (
-                  <CategorySelect 
+                  <CategorySelect
                     aggregations={aggregations}
                     setQuery={setQuery}
                     setValue={this.setCategories}
@@ -300,6 +310,15 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
               <ReactiveComponent
                 componentId={SearchComponents.DM}
                 defaultQuery={() => ({
+                  query: {
+                    "bool": {
+                      "must": {
+                        "match": {
+                          "_language": this.props.langcode,
+                        }
+                      }
+                    }
+                  },
                   aggs: {
                     [IndexFields.SECTOR]: {
                       terms: {

--- a/src/modules/decisions/components/form/filters/CategorySelect.tsx
+++ b/src/modules/decisions/components/form/filters/CategorySelect.tsx
@@ -18,13 +18,50 @@ const CategorySelect = ({ aggregations, setQuery, setValue, value, queryValue }:
   let categories: Array<any> = [];
   const { t } = useTranslation();
 
+  const getTranslatedCategory = (category: string) => {
+    switch (category) {
+      case "Hallintoasiat":
+        return t("CATEGORIES:00");
+      case "Henkilöstöasiat":
+        return t("CATEGORIES:01");
+      case "Talousasiat, verotus ja omaisuuden hallinta":
+        return t("CATEGORIES:02");
+      case "Lainsäädäntö ja lainsäädännön soveltaminen":
+        return t("CATEGORIES:03");
+      case "Kansainvälinen toiminta ja maahanmuuttopolitiikka":
+        return t("CATEGORIES:04");
+      case "Sosiaalitoimi":
+        return t("CATEGORIES:05");
+      case "Terveydenhuolto":
+        return t("CATEGORIES:06");
+      case "Tiedon hallinta":
+        return t("CATEGORIES:07");
+      case "Liikenne":
+        return t("CATEGORIES:08");
+      case "Turvallisuus ja yleinen järjestys":
+        return t("CATEGORIES:09");
+      case "Maankäyttö, rakentaminen ja asuminen":
+        return t("CATEGORIES:10");
+      case "Ympäristöasia":
+        return t("CATEGORIES:11");
+      case "Opetus- ja sivistystoimi":
+        return t("CATEGORIES:12");
+      case "Tutkimus- ja kehittämistoiminta":
+        return t("CATEGORIES:13");
+      case "Elinkeino- ja työvoimapalvelut":
+        return t("CATEGORIES:14");
+      default:
+        return category;
+    }
+  }
+
   if(
     aggregations &&
     aggregations.top_category_name &&
     aggregations.top_category_name.buckets.length
     ) {
     categories = aggregations.top_category_name.buckets.map((category: any) => ({
-      label: category.key,
+      label: getTranslatedCategory(category.key),
       value: category.key
     }));
   }
@@ -33,7 +70,7 @@ const CategorySelect = ({ aggregations, setQuery, setValue, value, queryValue }:
     if(queryValue.length) {
       setQuery({
         query: {
-          terms: { 
+          terms: {
             top_category_name: queryValue
           }
         },

--- a/src/modules/decisions/components/results/ResultCard.tsx
+++ b/src/modules/decisions/components/results/ResultCard.tsx
@@ -12,16 +12,17 @@ type Props = {
   color_class: string[],
   date: number,
   href: string,
+  lang_prefix: string,
   subject: string,
   _score: number,
   organization_name: string
 };
 
-const ResultCard = ({category, color_class, date, href, organization_name, subject, _score}: Props) => {
+const ResultCard = ({category, color_class, date, href, lang_prefix, organization_name, subject, _score}: Props) => {
   const colorClass = useDepartmentClasses(color_class);
 
   const handleClick = () => {
-    window.location.href=href
+    window.location.href = href.toString().replace('/fi/', lang_prefix);
   }
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -36,7 +37,7 @@ const ResultCard = ({category, color_class, date, href, organization_name, subje
   }
 
   return (
-    <div 
+    <div
       className={style.ResultCard}
       onClick={handleClick}
       onKeyPress={handleKeyPress}
@@ -72,7 +73,7 @@ const ResultCard = ({category, color_class, date, href, organization_name, subje
               <IconArrowRight size={'l'}/>
           </div>
         </div>
-    </div>  
+    </div>
   );
 }
 

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -37,10 +37,10 @@ const ResultsContainer = () => {
   };
   if(width > 1281) {
     cardWrapperStyles.justifyContent = 'space-between'
-  } 
+  }
 
   const dataField = sort === Sort.SCORE ? IndexFields.SCORE : IndexFields.MEETING_DATE;
-  const sortBy = (sort === Sort.SCORE || sort === Sort.DATE_DESC) ? 'desc' : 'asc'; 
+  const sortBy = (sort === Sort.SCORE || sort === Sort.DATE_DESC) ? 'desc' : 'asc';
 
   return (
     <div className={resultsStyles.ResultsContainer} ref={resultsContainer}>
@@ -132,6 +132,7 @@ const ResultsContainer = () => {
                     organization_name: item.organization_name,
                     date: item.meeting_date,
                     href: item.decision_url,
+                    lang_prefix: t('SEARCH:prefix'),
                     policymaker: '',
                     subject: item.subject,
                     _score: item._score

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -98,24 +98,30 @@ const ResultsContainer = () => {
               </span>
             </div>
           )}
-          defaultQuery={(value, props) => {
-            return {
-              query: {
-                function_score: {
-                  boost: 10,
-                  functions: [
-                    {gauss:
-                      {
-                        meeting_date: {
-                          scale: '365d'
-                        }
+          defaultQuery={() => ({
+            query: {
+              function_score: {
+                boost: 10,
+                query: {
+                  bool: {
+                    should: [
+                      {"match": {"_language": t('SEARCH:langcode')}},
+                      {"match": {"has_translation": false}}
+                    ]
+                  }
+                },
+                functions: [
+                  {gauss:
+                    {
+                      meeting_date: {
+                        scale: '365d'
                       }
                     }
-                  ]
-                }
+                  }
+                ]
               }
             }
-          }}
+          })}
           render={({ data }) => (
             <React.Fragment>
               <SortSelect

--- a/src/modules/decisions/enum/IndexFields.ts
+++ b/src/modules/decisions/enum/IndexFields.ts
@@ -12,7 +12,8 @@ export const IndexFields = {
   SCORE: '_score',
   ORG_NAME: 'organization_name',
   ORG_TYPE: 'organization_type',
-  SECTOR: 'sector'
+  SECTOR: 'sector',
+  HAS_TRANSLATION: 'has_translation'
 };
 
 export default IndexFields;

--- a/src/modules/policymakers/SearchContainer.tsx
+++ b/src/modules/policymakers/SearchContainer.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { ReactiveBase } from '@appbaseio/reactivesearch';
 
+import { useTranslation } from 'react-i18next';
+
 import Indices from '../../Indices';
 import FormContainer from './components/form/FormContainer';
 import ResultsContainer from './components/results/ResultsContainer';
@@ -19,6 +21,7 @@ type Props = {
 };
 
 const SearchContainer = ({ url }: Props) => {
+  const { t } = useTranslation();
   const [searchTriggered, setSearchStatus] = useState<boolean>(false);
 
   const triggerSearch = () => {
@@ -31,7 +34,10 @@ const SearchContainer = ({ url }: Props) => {
       app={Indices.PAATOKSET_POLICYMAKERS}
       theme={baseTheme}
       >
-        <FormContainer searchTriggered={searchTriggered} triggerSearch={triggerSearch} />
+        <FormContainer
+          langcode={t('SEARCH:langcode')}
+          searchTriggered={searchTriggered}
+          triggerSearch={triggerSearch} />
         {searchTriggered &&
           <ResultsContainer />
         }

--- a/src/modules/policymakers/components/form/FormContainer.tsx
+++ b/src/modules/policymakers/components/form/FormContainer.tsx
@@ -13,6 +13,7 @@ import formStyles from '../../../../common/styles/Form.module.scss';
 import classNames from 'classnames';
 
 type Props = {
+  langcode: string,
   searchTriggered: boolean,
   triggerSearch: Function
 }
@@ -28,7 +29,7 @@ type FormContainerState = {
 const getInitialValue = (key: string) => {
   const queryParam = getQueryParam(key);
   if(queryParam) {
-    return JSON.parse(queryParam); 
+    return JSON.parse(queryParam);
   }
   return [];
 }
@@ -133,7 +134,7 @@ class FormContainer extends Component<Props> {
           'wrapper'
         )}
       >
-        <form 
+        <form
           className={classNames(
             formStyles.FormContainer__form,
             'container'
@@ -151,16 +152,27 @@ class FormContainer extends Component<Props> {
           <div className={formStyles['FormContainer__lower-fields']}>
             <ReactiveComponent
               componentId={SearchComponents.SECTOR}
-              defaultQuery={() => ({
-                aggs: {
-                  [IndexFields.SECTOR]: {
-                    terms: {
-                      field: IndexFields.SECTOR,
-                      order: { _key: 'asc' }
+              defaultQuery={() => (
+                {
+                  query: {
+                    "bool": {
+                      "must": {
+                        "match": {
+                          "_language": this.props.langcode,
+                        }
+                      }
+                    }
+                  },
+                  aggs: {
+                    [IndexFields.SECTOR]: {
+                      terms: {
+                        field: IndexFields.SECTOR,
+                        order: { _key: 'asc' }
+                      }
                     }
                   }
                 }
-              })}
+              )}
               render={({ aggregations, setQuery }) => (
                 <SectorSelect
                   aggregations={aggregations}
@@ -172,7 +184,7 @@ class FormContainer extends Component<Props> {
               )}
               URLParams={true}
             />
-            <ReactiveComponent 
+            <ReactiveComponent
               componentId={SearchComponents.WILDCARD}
               customQuery={() => ({
                 query: {

--- a/src/modules/policymakers/components/results/ResultsContainer.tsx
+++ b/src/modules/policymakers/components/results/ResultsContainer.tsx
@@ -22,7 +22,7 @@ const ResultsContainer = () => {
   }
 
   return (
-    <div 
+    <div
       ref={resultsContainer}
       className={classNames(
         resultsStyles.ResultsContainer,
@@ -41,6 +41,22 @@ const ResultsContainer = () => {
         dataField={IndexFields.TITLE}
         onPageChange={scrollToResults}
         URLParams={true}
+        defaultQuery={() => (
+          {
+            query: {
+              "bool": {
+                "should": [
+                  {
+                    "match": {"_language": t('SEARCH:langcode')}
+                  },
+                  {
+                    "match": {"has_translation": false}
+                  }
+                ]
+              }
+            }
+          }
+        )}
         react={{
           or: [
             SearchComponents.SEARCH_BAR,

--- a/src/modules/policymakers/enum/IndexFields.ts
+++ b/src/modules/policymakers/enum/IndexFields.ts
@@ -1,5 +1,6 @@
 export const IndexFields = {
   TITLE: 'title',
+  LANGUAGE: '_language',
   ORGANIZATION_TYPE: 'field_organization_type.keyword',
   SECTOR: 'sector',
   HREF: 'search_api_url',
@@ -8,7 +9,8 @@ export const IndexFields = {
   DM_FIRST_NAME: 'field_first_name',
   DM_LAST_NAME: 'field_last_name',
   TRUSTEE_NAME: 'trustee_name',
-  TRUSTEE_TITLE: 'trustee_title'
+  TRUSTEE_TITLE: 'trustee_title',
+  HAS_TRANSLATION: 'has_translation'
 };
 
 export default IndexFields;


### PR DESCRIPTION
**Drupal setup**
- On your local drupal installation, checkout this branch: `PP-344-search-fixes`
- Run `make composer-install drush-cim drush-cr`
- If you don't have any data, run `make ahjo-migrations` (NOTE: you'll need the local proxy URL for this one. Also, edit the user permissions on the test site and add the following permissions for anonymous users: "Access external documents from Ahjo API")
- Rebuild and reindex all content in both indices:
  - https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/decisions
  - https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/policymakers

**To test**
- Checkout branch and start the app with `npm start`
- Decisions (set the data-type attribute to `decisions`)
  - Check that all interface texts are properly translated in swedish: http://localhost:3000/sv
  - The category dropdown should have translated values
  - The decisionmaker dropdown should have translated values
  - When you click a result, the URL should point to the swedish language version, for example: `/sv/asia...`
- Policymakers (set the data-type attribute to `policymakers`) 
  - Check that all interface texts are properly translated in swedish: http://localhost:3000/sv
  - The category dropdown should have translated values
  - The results should only have swedish titles
  - Change the language to finnish. The dropdowns should only have finnish values, and the results should only have finnish titles