### PR TITLE
PP-387: Stack decision results by issue

### DIFF
--- a/src/modules/decisions/components/form/SearchBar.tsx
+++ b/src/modules/decisions/components/form/SearchBar.tsx
@@ -21,7 +21,6 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
         IndexFields.ISSUE_SUBJECT,
         IndexFields.SUBJECT
       ]}
-      aggregationField={IndexFields.ISSUE_ID}
       placeholder={t('DECISIONS:search-bar-placeholder')}
       autosuggest={false}
       value={value}

--- a/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
+++ b/src/modules/decisions/components/form/filters/SelectedFiltersContainer.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { Option } from '../../../types/types';
 
 import './SelectedFiltersContainer.scss';
-import { setSelectionRange } from '@testing-library/user-event/dist/utils';
 
 type Props = {
   categories: Array<Option>,

--- a/src/modules/decisions/components/results/ResultCard.module.scss
+++ b/src/modules/decisions/components/results/ResultCard.module.scss
@@ -22,8 +22,20 @@
   }
 
   @media (min-width: 1200px) {
-    max-width: 384px; 
+    max-width: 384px;
   }
+}
+
+.MultipleResults {
+  position: relative;
+  top: -5px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #ccc;
+  box-shadow:
+    inset 0 -4px 0 0 #f4f4f4,
+    inset 0 -5px 0 0 #ccc,
+    inset 0 -10px 0 0 #f6f6f6,
+    inset 0 -11px 0 0 #ccc,
 }
 
 .PhantomCard {

--- a/src/modules/decisions/components/results/ResultCard.tsx
+++ b/src/modules/decisions/components/results/ResultCard.tsx
@@ -15,12 +15,14 @@ type Props = {
   lang_prefix: string,
   url_prefix: string,
   url_query: string,
+  issue_id: string,
+  doc_count: number,
   subject: string,
   _score: number,
   organization_name: string
 };
 
-const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix, url_query, organization_name, subject, _score}: Props) => {
+const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix, url_query, issue_id, doc_count, organization_name, subject, _score}: Props) => {
   const colorClass = useDepartmentClasses(color_class);
 
   const handleClick = () => {
@@ -38,9 +40,14 @@ const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix,
     formattedDate = format(new Date(date * 1000), 'dd.MM.yyyy');
   }
 
+  let cardClass = style.ResultCard;
+  if (doc_count > 1) {
+    cardClass += ' ' + style.MultipleResults;
+  }
+
   return (
     <div
-      className={style.ResultCard}
+      className={cardClass}
       onClick={handleClick}
       onKeyPress={handleKeyPress}
       tabIndex={0}
@@ -56,7 +63,7 @@ const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix,
         </div>
         <div className={style.ResultCard__title}>
           {process.env.REACT_APP_DEVELOPER_MODE &&
-            <span style={{color: 'red'}}>{ _score }</span>
+            <span style={{color: 'red'}}>Score: { _score }, Diary number: { issue_id }, Doc count: { doc_count },  </span>
           }
           <h2>{ subject }</h2>
         </div>

--- a/src/modules/decisions/enum/IndexFields.ts
+++ b/src/modules/decisions/enum/IndexFields.ts
@@ -4,7 +4,7 @@ export const IndexFields = {
   CONTENT_RESOLUTION: 'content_resolution',
   DECISION_CONTENT: 'decision_content',
   DECISION_MOTION: 'decision_motion',
-  ISSUE_ID: 'issue_id.keyword',
+  ISSUE_ID: 'issue_id',
   ISSUE_SUBJECT: 'issue_subject',
   MEETING_DATE: 'meeting_date',
   MEETING_POLICYMAKER_LINK: 'meeting_policymaker_link',


### PR DESCRIPTION
This PR bundles decision results based on diary number using the "collapse" and "aggs" elasticsearch query options. Collapse acts as a "distinct" selector and "aggs" is used to get the information about how many decisions are stacked.

**To test**
- Checkout branch, run `npm start`
- Turn on the `REACT_APP_DEVELOPER_MODE` env variable to help debugging (displays the diary number as debug info in each card)
- Make sure your Drupal installation has enough decisions and some decisions with the same diary number
- Do some test searches. You should never get multiple decisions with the same case ID
  - Note that this does break the result counter somewhat
- Change the size and sorting options. These shouldn't break the bundling
- The "top" result should respect the sorting option. You can test this easily by chaning the sorting from newest to oldest.