### PR TITLE
PP-255: Improved decision bundling

### DIFF
--- a/src/locales/locales.json
+++ b/src/locales/locales.json
@@ -38,7 +38,8 @@
       "topic": "Topic",
       "trustee": "Trustees",
       "choose-topic": "Choose topic",
-      "date-select": "Date range"
+      "date-select": "Date range",
+      "amount-label": "Decisions in the case"
     },
     "POLICYMAKERS": {
       "url-prefix": "decisionmakers",
@@ -114,7 +115,8 @@
       "topic": "Aihe",
       "trustee": "Viranhaltijat",
       "choose-topic": "Valitse aihe",
-      "date-select": "Ajankohta"
+      "date-select": "Ajankohta",
+      "amount-label": "Päätöksiä asiassa"
     },
     "POLICYMAKERS": {
       "url-prefix": "paattajat",
@@ -190,7 +192,8 @@
       "topic": "Ämne",
       "trustee": "Tjänsteinnehavare",
       "choose-topic": "Välj ämne",
-      "date-select": "Tidpunkt"
+      "date-select": "Tidpunkt",
+      "amount-label": "Beslut i ärenden"
     },
     "SECTORS": {
       "U320200": "Social- och hälsovårdsektorn",

--- a/src/modules/decisions/components/results/ResultCard.module.scss
+++ b/src/modules/decisions/components/results/ResultCard.module.scss
@@ -9,7 +9,7 @@
   overflow: hidden;
 
   &:hover {
-    .ResultCard__container {
+    .ResultCard__title h2 {
       text-decoration: underline;
     }
     .ResultCard__issue-link {
@@ -81,6 +81,11 @@
   font-size: 24px;
   line-height: 24px;
   font-weight: 500;
+  margin-bottom: 36px;
+}
+
+.ResultCard__amount {
+  margin-top: -20px;
   margin-bottom: 36px;
 }
 

--- a/src/modules/decisions/components/results/ResultCard.tsx
+++ b/src/modules/decisions/components/results/ResultCard.tsx
@@ -15,6 +15,7 @@ type Props = {
   lang_prefix: string,
   url_prefix: string,
   url_query: string,
+  amount_label: string,
   issue_id: string,
   doc_count: number,
   subject: string,
@@ -22,7 +23,7 @@ type Props = {
   organization_name: string
 };
 
-const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix, url_query, issue_id, doc_count, organization_name, subject, _score}: Props) => {
+const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix, url_query, amount_label, issue_id, doc_count, organization_name, subject, _score}: Props) => {
   const colorClass = useDepartmentClasses(color_class);
 
   const handleClick = () => {
@@ -66,6 +67,12 @@ const ResultCard = ({category, color_class, date, href, lang_prefix, url_prefix,
             <span style={{color: 'red'}}>Score: { _score }, Diary number: { issue_id }, Doc count: { doc_count },  </span>
           }
           <h2>{ subject }</h2>
+          {
+            doc_count > 1 &&
+              <div className={style.ResultCard__amount}>
+                <p>{amount_label}: {doc_count}</p>
+              </div>
+          }
         </div>
       </div>
       <div className={style.ResultCard__footer}>

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -181,6 +181,7 @@ const ResultsContainer = () => {
                     lang_prefix: t('SEARCH:prefix'),
                     url_prefix: t('DECISIONS:url-prefix'),
                     url_query: t('DECISIONS:url-query'),
+                    amount_label: t('DECISIONS:amount-label'),
                     issue_id: item.issue_id,
                     doc_count: doc_count,
                     policymaker: '',


### PR DESCRIPTION
**To test**
- Checkout branch, run `npm start`
- Make sure you have indexed content from your local Drupal instance including decisions that have the same diary number
- Do some searches. The decisions bundled by diary number should have a "Päätöksiä asiassa: x" text showing how many items are bundled
- Check the different language versions. The amount label should be translated according to the language selection