### PR TITLE
UHF-8852 search language handling

### DIFF
--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -64,10 +64,16 @@ const ResultsContainer = () => {
             bool: {
               must: [
                 {"exists": {"field": "meeting_date"}},
-              ],
-              should: [
-                {"match": {"_language": t('SEARCH:langcode')}},
-                {"match": {"has_translation": false}}
+                {
+                  // Query for documents that are translated to current
+                  // language, or they are not translated at all.
+                  bool: {
+                    should: [
+                      {"term": {"_language": t('SEARCH:langcode')}},
+                      {"term": {"has_translation": false}}
+                    ]
+                  }
+                }
               ]
             }
           },

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -187,44 +187,43 @@ const ResultsContainer = () => {
               >
                 {
                   data.map((item: any) => {
+                    // Item mapping.
+                    const {id} = item;
+                    // Check document count for collapsed search results.
+                    const aggregations = rawData.aggregations;
+                    let doc_count = 1;
 
-                  // Item mapping.
-                  const {id} = item;
-                  // Check document count for collapsed search results.
-                  const aggregations = rawData.aggregations;
-                  let doc_count = 1;
-
-                  if (item.unique_issue_id && item.unique_issue_id[0] && aggregations && aggregations.unique_issue_id && aggregations.unique_issue_id.buckets.length) {
-                    const buckets = aggregations.unique_issue_id.buckets;
-                    for (let i = 0; i < buckets.length; i++) {
-                      if (buckets[i].key === item.unique_issue_id[0]) {
-                        doc_count = buckets[i].doc_count;
+                    if (item.unique_issue_id && item.unique_issue_id[0] && aggregations && aggregations.unique_issue_id && aggregations.unique_issue_id.buckets.length) {
+                      const buckets = aggregations.unique_issue_id.buckets;
+                      for (let i = 0; i < buckets.length; i++) {
+                        if (buckets[i].key === item.unique_issue_id[0]) {
+                          doc_count = buckets[i].doc_count;
+                        }
                       }
                     }
-                  }
 
-                  const resultProps = {
-                    category: item.top_category_name,
-                    color_class: item.color_class,
-                    organization_name: item.organization_name,
-                    date: item.meeting_date,
-                    href: item.decision_url,
-                    lang_prefix: t('SEARCH:prefix'),
-                    url_prefix: t('DECISIONS:url-prefix'),
-                    url_query: t('DECISIONS:url-query'),
-                    amount_label: t('DECISIONS:amount-label'),
-                    issue_id: item.issue_id,
-                    unique_issue_id: item.unique_issue_id,
-                    doc_count: doc_count,
-                    policymaker: '',
-                    subject: item.subject,
-                    issue_subject: item.issue_subject,
-                    _score: item._score
-                  };
-                  return <ResultCard
-                    key={id}
-                    {...resultProps}
-                  />
+                    const resultProps = {
+                      category: item.top_category_name,
+                      color_class: item.color_class,
+                      organization_name: item.organization_name,
+                      date: item.meeting_date,
+                      href: item.decision_url,
+                      lang_prefix: t('SEARCH:prefix'),
+                      url_prefix: t('DECISIONS:url-prefix'),
+                      url_query: t('DECISIONS:url-query'),
+                      amount_label: t('DECISIONS:amount-label'),
+                      issue_id: item.issue_id,
+                      unique_issue_id: item.unique_issue_id,
+                      doc_count: doc_count,
+                      policymaker: '',
+                      subject: item.subject,
+                      issue_subject: item.issue_subject,
+                      _score: item._score
+                    };
+                    return <ResultCard
+                      key={id}
+                      {...resultProps}
+                    />
                 })}
                 {data.length % 3 !== 0 &&
                   <PhantomCard />


### PR DESCRIPTION
# [UHF-8852](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Fix elasticsearch query so that translated results in wrong language are not shown. Users should see results that have no translations and results that are translated to their current language.  

## How to install

* Clone this repository: `git clone git@github.com:City-of-Helsinki/paatokset-search.git`
* Checkout to this branch: `git checkout UHF-8852-search-language-handling`
* Run `npm i`. Requires python <= 3.10.
* Use production elasticsearch: `export REACT_APP_ELASTIC_URL=https://paatokset-search.api.hel.fi`
* Run `sed -i '' 's/data-type="policymakers"/data-type="decisions"/g' public/index.html` (develop decision search instead of policymaker search)
* Run `npm run start`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Compare results between [prod](https://paatokset.hel.fi/fi/asia?dm=%22Kaupunginvaltuusto%22&results=1&from=29.3.2023&to=5.4.2023) and [localhost:3000](http://localhost:3000?dm=%22Kaupunginvaltuusto%22&results=1&from=29.3.2023&to=5.4.2023).
* [x] [Change the language to Swedish](http://localhost:3000/sv/). Try to find decision that does not have Swedish translation. They should be searchable.
* [x] Try some other search queries?
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* City-of-Helsinki/helsinki-paatokset#311

[UHF-8852]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ