### PR TITLE
UHF-8985 Display full organization path in policymaker cards

### DIFF
--- a/src/modules/policymakers/components/results/ResultCard.module.scss
+++ b/src/modules/policymakers/components/results/ResultCard.module.scss
@@ -33,8 +33,10 @@
   }
 
   &:hover {
-    text-decoration: underline;
-  
+    .ResultCard__title {
+      text-decoration: underline;
+    }
+
     svg {
      transform: translate(10px);
     }

--- a/src/modules/policymakers/components/results/ResultCard.module.scss
+++ b/src/modules/policymakers/components/results/ResultCard.module.scss
@@ -16,6 +16,7 @@
   .titleContainer {
     display: flex;
     flex-flow: column nowrap;
+    width: 100%;
   }
 
   .departmentHighlight {
@@ -36,6 +37,19 @@
   
     svg {
      transform: translate(10px);
+    }
+
+    .ResultCard__sub-title {
+      svg {
+        transform: none;
+      }
+    }
+  }
+
+  .ResultCard__sub-title {
+    svg {
+      --icon-size: 18px;
+      margin-top: 6px;
     }
   }
 }

--- a/src/modules/policymakers/components/results/ResultCard.tsx
+++ b/src/modules/policymakers/components/results/ResultCard.tsx
@@ -1,4 +1,4 @@
-import { IconArrowRight } from 'hds-react';
+import { IconArrowRight, IconAngleRight } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import useDepartmentClasses from '../../../../hooks/useDepartmentClasses';
 
@@ -6,16 +6,15 @@ import style from './ResultCard.module.scss';
 
 type Props = {
   color_class: string[],
-  field_dm_org_name?: string,
-  sector ?: string,
   key: string,
   title: string,
   trustee_name?: string,
   trustee_title?: string,
-  url?: string
+  url?: string,
+  organization_hierarchy?: string[]
 }
 
-const ResultCard = ({color_class, field_dm_org_name, sector, key, title, trustee_name, trustee_title, url}: Props) => {
+const ResultCard = ({color_class, key, title, trustee_name, trustee_title, url, organization_hierarchy}: Props) => {
   const { t } = useTranslation();
   const colorClass = useDepartmentClasses(color_class);
   const translatedTrusteeTitle = (trustee_title:string) => {
@@ -29,19 +28,16 @@ const ResultCard = ({color_class, field_dm_org_name, sector, key, title, trustee
       return trustee_title;
     }
   }
-  const formattedSectorAndOrg = (sector:string|undefined, field_dm_org_name:string|undefined) => {
-    if (sector && field_dm_org_name) {
-      if (sector.toString() === field_dm_org_name.toString()) {
-        return sector;
-      }
-      return sector + ' - ' + field_dm_org_name;
+
+  const formattedOrganizations = (organization_hierarchy:string[]|undefined) => {
+    if (organization_hierarchy) {
+      let organization_path = organization_hierarchy.map((organization, index) => (  
+        <span>{index !== 0 ? <IconAngleRight /> : ''}{organization}</span>  
+      ))
+
+      return organization_path;
     }
-    else if (field_dm_org_name) {
-      return field_dm_org_name;
-    }
-    else if (sector) {
-      return sector;
-    }
+
     return false;
   }
 
@@ -87,8 +83,8 @@ const ResultCard = ({color_class, field_dm_org_name, sector, key, title, trustee
             <div className={style['ResultCard__sub-title']}>{ translatedTrusteeTitle(trustee_title) }</div>
           }
           {
-            formattedSectorAndOrg(sector, field_dm_org_name) &&
-            <div className={style['ResultCard__sub-title']}>{ formattedSectorAndOrg(sector, field_dm_org_name) }</div>
+            formattedOrganizations(organization_hierarchy) &&
+            <div className={style['ResultCard__sub-title']}>{ formattedOrganizations(organization_hierarchy) }</div>
           }
         </div>
         <IconArrowRight size='m' />

--- a/src/modules/policymakers/components/results/ResultCard.tsx
+++ b/src/modules/policymakers/components/results/ResultCard.tsx
@@ -11,7 +11,7 @@ type Props = {
   trustee_name?: string,
   trustee_title?: string,
   url?: string,
-  organization_hierarchy?: string[]
+  organization_hierarchy: string[]
 }
 
 const ResultCard = ({color_class, key, title, trustee_name, trustee_title, url, organization_hierarchy}: Props) => {
@@ -29,17 +29,13 @@ const ResultCard = ({color_class, key, title, trustee_name, trustee_title, url, 
     }
   }
 
-  const formattedOrganizations = (organization_hierarchy:string[]|undefined) => {
-    if (organization_hierarchy) {
-      let organization_path = organization_hierarchy.map((organization, index) => (  
+  const formattedOrganizations = (organization_hierarchy:string[]) => (
+    organization_hierarchy.map(
+      (organization, index) => (  
         <span>{index !== 0 ? <IconAngleRight /> : ''}{organization}</span>  
-      ))
-
-      return organization_path;
-    }
-
-    return false;
-  }
+      )
+    )
+  )
 
   if (typeof url !== 'undefined') {
     url = url.toString();
@@ -47,20 +43,20 @@ const ResultCard = ({color_class, key, title, trustee_name, trustee_title, url, 
       url = url.toString().replace('/fi/', t('SEARCH:prefix')).replace('paattajat', t('POLICYMAKERS:url-prefix'));
     }
     else if (url.includes('/sv/')) {
-      url = url.toString().replace('/sv/', t('SEARCH:prefix')).replace('beslutsfattare', t('POLICYMAKERS:url-prefix'));;
+      url = url.toString().replace('/sv/', t('SEARCH:prefix')).replace('beslutsfattare', t('POLICYMAKERS:url-prefix'));
     }
     else if (url.includes('/en/')) {
-      url = url.toString().replace('/en/', t('SEARCH:prefix')).replace('decisionmakers', t('POLICYMAKERS:url-prefix'));;
+      url = url.toString().replace('/en/', t('SEARCH:prefix')).replace('decisionmakers', t('POLICYMAKERS:url-prefix'));
     }
 
     if (url.includes('paattajat')) {
       url = url.toString().replace('paattajat', t('POLICYMAKERS:url-prefix'));
     }
     else if (url.includes('beslutsfattare')) {
-      url = url.toString().replace('beslutsfattare', t('POLICYMAKERS:url-prefix'));;
+      url = url.toString().replace('beslutsfattare', t('POLICYMAKERS:url-prefix'));
     }
     else if (url.includes('decisionmakers')) {
-      url = url.toString().replace('decisionmakers', t('POLICYMAKERS:url-prefix'));;
+      url = url.toString().replace('decisionmakers', t('POLICYMAKERS:url-prefix'));
     }
 
   }
@@ -83,7 +79,7 @@ const ResultCard = ({color_class, key, title, trustee_name, trustee_title, url, 
             <div className={style['ResultCard__sub-title']}>{ translatedTrusteeTitle(trustee_title) }</div>
           }
           {
-            formattedOrganizations(organization_hierarchy) &&
+            organization_hierarchy &&
             <div className={style['ResultCard__sub-title']}>{ formattedOrganizations(organization_hierarchy) }</div>
           }
         </div>


### PR DESCRIPTION
[UHF-8985](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8985)

## What was done
<!-- Describe what was done -->

* Display full organization path in the result cards of the policymaker search.

## How to install and test

* Follow the instructions in https://github.com/City-of-Helsinki/helsinki-paatokset/pull/352

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/352

[UHF-8985]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ