### PR TITLE
UHF-8985: Show full combined title in policymaker autosuggest results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,11 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script>
+      // Mock drupalSettings in development to prevent errors.
+      window.drupalSettings = {
+      }
+    </script>
     <style>
       :root {
         --color-sumu: #9fc9eb;

--- a/src/modules/policymakers/components/form/SearchBar.tsx
+++ b/src/modules/policymakers/components/form/SearchBar.tsx
@@ -38,6 +38,11 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
           if (typeof data[i].source.trustee_name === 'undefined' && data[i].source.has_translation[0] === true && data[i].source._language !== t('SEARCH:langcode')) {
             continue;
           }
+
+          // Always show combined title if one exists.
+          if (data[i].source.decisionmaker_combined_title && data[i].source.decisionmaker_combined_title[0]) {
+            subject = data[i].source.decisionmaker_combined_title[0];
+          }
           parsedData.push({
             label: subject,
             value: subject


### PR DESCRIPTION
**To test**
- On your local Drupal, checkout this branch: [UHF-8985-organization-path-fixes](https://github.com/City-of-Helsinki/helsinki-paatokset/pull/367)
- Reindex policymakers
- Make sure your env file is fetching data from your local index
- Run `npm start` with the policymakers search active
- Write something in the search field. All the suggestions should follow this format: `[title] - [sector name] - [above org name]` (some might just have two sections, but none should have only the title). 
- Read code changes