### PR TITLE
UHF-9878: Change organization filter display format and change sorting logic

### DIFF
--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -313,37 +313,47 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
         const organization = searchfield_data.organization;
         const organization_above = searchfield_data.organization_above;
 
+        let sort_label = '';
         let label = '';
 
-        if (sector && sector[langcode]){
-          label = `${sector[langcode]}`;
+        // Special cases for city council and board
+        if (searchfield_data.id === '02900' || searchfield_data.id === '00400') {
+          label = `${organization[langcode]}`;
+          sort_label = `0 - ${organization[langcode]}`;
+        } else {
+          // Formatting for 
+          if (organization && organization[langcode]) {
+            label = `${organization[langcode]}`;
+            sort_label = `${organization[langcode]}`;
+          }
+          if (organization_above && organization_above[langcode]) {
+            label = `${label}, ${organization_above[langcode]}`;
+            sort_label = `${sort_label}, ${organization_above[langcode]}`;
+          }
+          if (sector && sector[langcode]){
+            label = `${label} - ${sector[langcode]}`;
+            sort_label = `${sector[langcode]} - ${sort_label}`;
+          }
         }
-        if (organization && organization[langcode]) {
-          label = label ? `${label} - ${organization[langcode]}` : organization[langcode];
-        }
-        if (organization_above && organization_above[langcode]) {
-          label = label ? `${label} - ${organization_above[langcode]}` : organization_above[langcode];
-        }
+        
 
         return {
           key: searchfield_data.id,
           value: searchfield_data.id,
-          label: label
+          label: label,
+          sort_label: sort_label
         }
       })
       .reduce((accumulator: combobox_item[], current: combobox_item) => {
           // Add ID to combobox label if the item label is duplicate.
           accumulator.forEach((item:combobox_item) => {
-            if (item.label == current.label) {
+            if (item.label === current.label) {
               current.label = `${current.label} (${current.key})`
             }
           });
           accumulator.push(current)
           return accumulator;
       }, [])
-      .sort((a:combobox_item, b:combobox_item) => {
-        return a.label < b.label
-      })
 
       // handle query parameters, select correct dropdown options for the query parameters
       if (this.state.dms) {

--- a/src/modules/decisions/components/form/filters/DecisionmakerSelect.tsx
+++ b/src/modules/decisions/components/form/filters/DecisionmakerSelect.tsx
@@ -18,9 +18,12 @@ type Props = {
 
 const DecisionmakerSelect = ({setQuery, setValues, values, opts, queryValues, langcode}: Props) => {
   const { t } = useTranslation();
-  const specialCases = [
-    {label: t('DECISIONS:trustee'), value: SpecialCases.TRUSTEE, key: SpecialCases.TRUSTEE},
-  ];
+  const specialCases = [{
+    label: t('DECISIONS:trustee'),
+    sort_label: '0 - ' + t('DECISIONS:trustee'),
+    value: SpecialCases.TRUSTEE,
+    key: SpecialCases.TRUSTEE,
+  }];
 
   const [selected, setSelected] = useState(queryValues);
 
@@ -30,6 +33,7 @@ const DecisionmakerSelect = ({setQuery, setValues, values, opts, queryValues, la
   .map((sector:any) => {
     return {
       label: t('SECTORS:' + sector.value),
+      sort_label: t('SECTORS:' + sector.value),
       value: sector.value,
     };
   })
@@ -37,8 +41,8 @@ const DecisionmakerSelect = ({setQuery, setValues, values, opts, queryValues, la
 
   let options: any[] = [];
   options = sectors.concat(specialCases, opts);
-  options.sort((a, b) => a.label.localeCompare(b.label));
-
+  options.sort((a, b) => a.sort_label.localeCompare(b.sort_label));
+  
   const triggerQuery = useCallback(() => {
     if(queryValues) {
       const specialCaseValues = [

--- a/src/modules/decisions/types/types.ts
+++ b/src/modules/decisions/types/types.ts
@@ -27,6 +27,7 @@ export type aggregate = {
 
 export type combobox_item = {
   label: string,
+  sort_label: string,
   key: string,
   value: string
 }


### PR DESCRIPTION
This PR changes the display format for organizations and adds logic for sorting. Also adds city council and board as special cases to be shown in the beginning of the list.