### PR TITLE
UHF-11708: Updating the way simple_query_string filtering is added

### DIFF
--- a/src/modules/decisions/components/form/FormContainer.tsx
+++ b/src/modules/decisions/components/form/FormContainer.tsx
@@ -504,59 +504,47 @@ class FormContainer extends React.Component<FormContainerProps, FormContainerSta
                 )}
                 URLParams={true}
               />
-                <ReactiveComponent
-                  componentId={SearchComponents.DM}
-                  onData={this.handleDecisionMakerLabels}
-                  defaultQuery={() => ({
-                    size: 10000,
-                    query: [
-                      {
-                        terms: {
-                            "_index": [Indices.PAATOKSET_POLICYMAKERS]
-                          }
+              <ReactiveComponent
+                componentId={SearchComponents.DM}
+                onData={this.handleDecisionMakerLabels}
+                defaultQuery={() => ({
+                  size: 10000,
+                  query: [
+                    {
+                      terms: {
+                          "_index": [Indices.PAATOKSET_POLICYMAKERS]
+                        }
+                    },
+                    {
+                      terms: {
+                          [IndexFields.LANGUAGE]: [this.props.langcode]
+                        }
                       },
-                      {
-                        terms: {
-                            [IndexFields.LANGUAGE]: [this.props.langcode]
-                          }
-                        },
-                    ],
-                    _source: {
-                      "include": [IndexFields.POLICYMAKER_STRING]
-                    }
-                  })}
-                  render={({setQuery}) => (
-                    <DecisionmakerSelect
-                      setQuery={setQuery}
-                      setValues={this.setDms}
-                      values={selectedDms}
-                      opts={this.state.decisionmakers}
-                      queryValues={queryDms}
-                      langcode={this.props.langcode}
-                    />
-                  )}
-                  URLParams={true}
-                />
+                  ],
+                  _source: {
+                    "include": [IndexFields.POLICYMAKER_STRING]
+                  }
+                })}
+                render={({setQuery}) => (
+                  <DecisionmakerSelect
+                    setQuery={setQuery}
+                    setValues={this.setDms}
+                    values={selectedDms}
+                    opts={this.state.decisionmakers}
+                    queryValues={queryDms}
+                    langcode={this.props.langcode}
+                  />
+                )}
+                URLParams={true}
+              />
               <ReactiveComponent
                 componentId={SearchComponents.WILDCARD}
                 customQuery={(props) => {
-                  return {query: {
-                    wildcard: {
-                      'subject.keyword': `*${wildcardPhrase}*`
-                    }
-                  }}
-                }}
-              />
-              <ReactiveComponent
-                componentId={SearchComponents.OPERATORS}
-                customQuery={(props) => {
-                  if (isOperatorSearch(wildcardPhrase)) {
+                  if (!isOperatorSearch(wildcardPhrase)) {
                     return {
                       query: {
-                        'simple_query_string': {
-                          'query': wildcardPhrase,
-                          'default_operator': 'or',
-                          'analyze_wildcard': true,
+                        wildcard: {
+                          'subject.keyword': `*${wildcardPhrase}*`
                         }
                       }
                     }

--- a/src/modules/decisions/components/form/SearchBar.tsx
+++ b/src/modules/decisions/components/form/SearchBar.tsx
@@ -13,6 +13,56 @@ import { OperatorGuideContext } from '../../../../index';
 const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value: string|undefined, setValue: any, URLParams: any, searchLabel: string|undefined, triggerSearch: any}>((props, ref) => {
   const { value, setValue, URLParams, searchLabel, triggerSearch } = props;
   const { t } = useTranslation();
+  const query = (value: string) => {
+    const dataFields = [
+      `${IndexFields.SUBJECT}^100`,
+      `${IndexFields.ISSUE_SUBJECT}^50`,
+      `${IndexFields.DECISION_CONTENT}^10`,
+      `${IndexFields.DECISION_MOTION}^1`
+    ];
+    const query = {
+      "bool": {
+        // Add simple query string filter if the value contains an operator.
+        ...((value && isOperatorSearch(value)) ? {
+          "filter": {
+            "simple_query_string": {
+              "query": value,
+              "default_operator": 'or',
+              "analyze_wildcard": true,
+            }
+          }} : {}),
+        "should": [
+          {
+            "multi_match": {
+              "query": value,
+              "fields": dataFields,
+              "type": "best_fields",
+              "operator": "or",
+              "fuzziness": 0
+            }
+          },
+          {
+            "multi_match": {
+              "query": value,
+              "fields": dataFields,
+              "type": "phrase",
+              "operator": "or"
+            }
+          },
+          {
+            "multi_match": {
+              "query": value,
+              "fields": dataFields,
+              "type": "phrase_prefix",
+              "operator": "or"
+            }
+          }
+        ],
+      },
+    };
+
+    return query;
+  };
 
   const dataSearch = (
     <DataSearch
@@ -26,58 +76,16 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
         IndexFields.DECISION_CONTENT,
         IndexFields.DECISION_MOTION
       ]}
-      defaultQuery = {(value) => {
-        const dataFields = [
-          `${IndexFields.SUBJECT}^100`,
-          `${IndexFields.ISSUE_SUBJECT}^50`,
-          `${IndexFields.DECISION_CONTENT}^10`,
-          `${IndexFields.DECISION_MOTION}^1`
-        ];
-        const query = {
-          "bool": {
-            // Add simple query string filter if the value contains an operator.
-            ...((value && isOperatorSearch(value)) ? {
-              "filter": {
-                "simple_query_string": {
-                  "query": value,
-                  "default_operator": 'or',
-                  "analyze_wildcard": true,
-                }
-              }} : {}),
-            "should": [
-              {
-                "multi_match": {
-                  "query": value,
-                  "fields": dataFields,
-                  "type": "best_fields",
-                  "operator": "or",
-                  "fuzziness": 0
-                }
-              },
-              {
-                "multi_match": {
-                  "query": value,
-                  "fields": dataFields,
-                  "type": "phrase",
-                  "operator": "or"
-                }
-              },
-              {
-                "multi_match": {
-                  "query": value,
-                  "fields": dataFields,
-                  "type": "phrase_prefix",
-                  "operator": "or"
-                }
-              }
-            ],
-          },
-        };
-
+      defaultQuery={(value) => {
         return {
-          "query": query,
+          "query": query(value),
           "size": 10,
           "_source": { "includes": ['*'], "excludes": [] },
+        };
+      }}
+      customQuery={(value) => {
+        return {
+          "query": query(value),
         };
       }}
       value={value}

--- a/src/modules/decisions/components/results/ResultsContainer.tsx
+++ b/src/modules/decisions/components/results/ResultsContainer.tsx
@@ -145,7 +145,6 @@ const ResultsContainer = () => {
             SearchComponents.CATEGORY,
             SearchComponents.MEETING_DATE,
             SearchComponents.DM,
-            SearchComponents.OPERATORS
           ]
         }}
         renderResultStats={(stats) => (
@@ -253,7 +252,8 @@ const ResultsContainer = () => {
                     key={id.toString()}
                     {...resultProps}
                   />
-              })}
+                })
+              }
               {data.length % 3 !== 0 &&
                 <PhantomCard />
               }

--- a/src/modules/decisions/enum/SearchComponents.ts
+++ b/src/modules/decisions/enum/SearchComponents.ts
@@ -4,7 +4,6 @@ export const SearchComponents = {
   MEETING_DATE: 'meeting_date',
   RESULTS: 'results',
   WILDCARD: 'wildcard',
-  OPERATORS: 'operators',
   DM: 'dm'
 };
 


### PR DESCRIPTION
# [UHF-11708](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11708)

A follow-up to #49 .

Updating the way simple_query_string filtering is added to search results to overcome occasional stale results issue when changing the search phrase and submitting the form again.

## How to install

* Checkout this repo and this branch in your local, then
  * Edit project root `.env`-file and add `REACT_APP_ELASTIC_URL=https://paatokset-search.api.hel.fi/` to test against production index.
  *  Edit `/public/index.html` and make sure `data-type="decisions"` root element is the one not commented out.
  * `nvm use`
  * `npm install`
  * `NODE_OPTIONS=--openssl-legacy-provider npm start`

## How to test

* Compare this behaviour between current dev and this branch. Do not select anything from the suggestions but always submit the form with your own search phrase:
  * In dev: go to https://nginx-paatokset-test.agw.arodevtest.hel.fi/fi/asia
  * In local: go to http://localhost:3000/
  * [ ] First search with `viikki +esiopetus` --> both should give 0 results
  * [ ] Then search with `viikki +-esiopetus` --> local should give results, but dev will still give 0 results


[UHF-11527]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-11708]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ