### PR TITLE
UHF-11274 Added support for diary number search

### DIFF
--- a/src/modules/decisions/components/form/SearchBar.tsx
+++ b/src/modules/decisions/components/form/SearchBar.tsx
@@ -18,7 +18,8 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
       `${IndexFields.SUBJECT}^100`,
       `${IndexFields.ISSUE_SUBJECT}^50`,
       `${IndexFields.DECISION_CONTENT}^10`,
-      `${IndexFields.DECISION_MOTION}^1`
+      `${IndexFields.DECISION_MOTION}^1`,
+      `${IndexFields.ISSUE_ID}^100`,
     ];
     const query = {
       "bool": {
@@ -74,7 +75,8 @@ const SearchBar = React.forwardRef<Component<DataSearchProps, any, any>, {value:
         IndexFields.SUBJECT,
         IndexFields.ISSUE_SUBJECT,
         IndexFields.DECISION_CONTENT,
-        IndexFields.DECISION_MOTION
+        IndexFields.DECISION_MOTION,
+        IndexFields.ISSUE_ID,
       ]}
       defaultQuery={(value) => {
         return {


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/UHF-11274

**What was done**

- Added support for diary number search (issue_id is the name of field_diary_number in elastic)

**How to install**
* Make sure your Päätökset instance is up and running on correct branch.
  * `git checkout UHF-11274`
  * `make fresh`
* Run `make drush-cr`
* Go to https://helsinki-paatokset.docker.so/fi/asia and check if you have data in the search, if not go [here](https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api) and index a bit of meetings, decisions and policymakers
* Get the react app running
  * `git checkout UHF-11274`
  * Make sure in your .env file you have the local elastic url defined for `REACT_APP_ELASTIC_UR`
  *  Run `NODE_OPTIONS=--openssl-legacy-provider npm start`

**How to test**
  
- [x]  Test the search that it works with a diary number
- [x]  For debugging purposes you can add to ResultsContainer.tsx (under decisions folder) a console.log on row 251 that prints the resultProps so that you can see that the results contain the correct diary number (issue_id)
- [x] Check that the code follows our standards